### PR TITLE
Fixed video translation being being set to 0 when parallax is enabled.

### DIFF
--- a/backgroundVideo.js
+++ b/backgroundVideo.js
@@ -183,7 +183,8 @@
                 scrollPos = this.options.$window.scrollTop(),
                 scaleObject = this.scaleObject($video, me.options.$videoWrap),
                 xPos = scaleObject.xPos,
-                yPos = scaleObject.yPos;
+                yPos = scaleObject.yPos,
+                origYPos = yPos;
 
             // Check for parallax
             if(this.options.parallax) {
@@ -193,6 +194,7 @@
                 } else {
                     yPos = this.calculateYPos(0);
                 }
+                yPos -= origYPos;
             } else {
                 yPos = -yPos;
             }


### PR DESCRIPTION
When parallax is on, the video wasn't being translated to the center of the outer-wrap because yPos was being  set to 0. I just save de yPos that comes from scaleObject and subtract it from yPos after the parallax verification, achieving the intended translation to keep the video in the center of the screen.

Before:
![2015-03-13-131503_1366x768_scrot](https://cloud.githubusercontent.com/assets/7232385/6638965/12abda98-c983-11e4-9f15-95e346a2a139.png)

After:
![2015-03-13-131422_1366x768_scrot](https://cloud.githubusercontent.com/assets/7232385/6638950/e429ad3a-c982-11e4-88ab-b9a54dc8e3a4.png)
